### PR TITLE
EEPROM byte write should return ACK

### DIFF
--- a/xboot.c
+++ b/xboot.c
@@ -585,6 +585,7 @@ int main(void)
                 {
                         EEPROM_write_byte(address, get_char());
                         address++;
+                        send_char(REPLY_ACK);
                 }
                 // Read EEPROM memory
                 else if (val == CMD_READ_EEPROM_BYTE)


### PR DESCRIPTION
According to avr109 datasheet (for example here: http://www.gaw.ru/pdf/Atmel/app/avr/avr109.pdf section _Protocol_) EEPROM byte write command ('D') should return '\r' ACK byte.
