### PR TITLE
Improve the UART timing.

### DIFF
--- a/xboot.h
+++ b/xboot.h
@@ -190,8 +190,8 @@
 #define UART_BSCALE_VALUE       0
 #define UART_CLK2X              0
 #elif (F_CPU == 32000000L) && (UART_BAUD_RATE == 115200)
-#define UART_BSEL_VALUE         16
-#define UART_BSCALE_VALUE       0
+#define UART_BSEL_VALUE         1047
+#define UART_BSCALE_VALUE       -6
 #define UART_CLK2X              0
 // None of the above, so calculate something
 #else


### PR DESCRIPTION
I was getting communication errors with the default UART values.  These values work reliably for me @ 32 MHz and 115200 baud on a Xmega32a4u.
