### PR TITLE
Clear only the watchdog bit in MCUSR before resetting the watchdog.

### DIFF
--- a/xboot.c
+++ b/xboot.c
@@ -309,7 +309,7 @@ int main(void)
         
 #ifndef __AVR_XMEGA__
         // ATMEGA must reset via watchdog, so turn it off
-        MCUSR = 0;
+	MCUSR &= ~(1 << WDRF);
         wdt_disable();
 #endif
         


### PR DESCRIPTION
Preserve other status flags so that user application can find out reason for reboot.