### PR TITLE
Watchdog reset in blocking functions

### DIFF
--- a/fifo.c
+++ b/fifo.c
@@ -136,10 +136,18 @@ void fifo_send_char_blocking(uint8_t c)
 {
 #ifdef __AVR_XMEGA__
         while (FIFO_CTL_PORT.IN & _BV(FIFO_TXE_N))
+        {
+                #ifdef USE_WATCHDOG
+                WDT_Reset();
+                #endif // USE_WATCHDOG
+        };
 #else // __AVR_XMEGA__
         while (FIFO_CTL_PORT_PIN & _BV(FIFO_TXE_N))
-#endif // __AVR_XMEGA__
         {
+                #ifdef USE_WATCHDOG
+                wdt_reset();
+                #endif // USE_WATCHDOG
         };
+#endif // __AVR_XMEGA__
         fifo_send_char(c);
 }

--- a/uart.h
+++ b/uart.h
@@ -48,9 +48,15 @@
 // send character
 #define uart_send_char(c) UART_DEVICE.DATA = (c)
 // send character, block until it is completely sent
+#ifdef USE_WATCHDOG
+#define uart_send_char_blocking(c) do {uart_send_char(c); \
+    while (!(UART_DEVICE.STATUS & USART_TXCIF_bm)) { WDT_Reset(); } \
+    UART_DEVICE.STATUS |= USART_TXCIF_bm; } while (0)
+#else // USE_WATCHDOG
 #define uart_send_char_blocking(c) do {uart_send_char(c); \
     while (!(UART_DEVICE.STATUS & USART_TXCIF_bm)) { } \
     UART_DEVICE.STATUS |= USART_TXCIF_bm; } while (0)
+#endif // USE_WATCHDOG
 
 #else // __AVR_XMEGA__
 
@@ -61,9 +67,15 @@
 // send character
 #define uart_send_char(c) UART_UDR = (c)
 // send character, block until it is completely sent
+#ifdef USE_WATCHDOG
+#define uart_send_char_blocking(c) do {uart_send_char(c); \
+    while (!(UART_UCSRA & _BV(TXC0))) { wdt_reset(); } \
+    UART_UCSRA |= _BV(TXC0); } while (0)
+#else // USE_WATCHDOG
 #define uart_send_char_blocking(c) do {uart_send_char(c); \
     while (!(UART_UCSRA & _BV(TXC0))) { } \
     UART_UCSRA |= _BV(TXC0); } while (0)
+#endif // USE_WATCHDOG
 
 #endif // __AVR_XMEGA__
 

--- a/xboot.c
+++ b/xboot.c
@@ -416,11 +416,13 @@ int main(void)
                 // --------------------------------------------------
                 // End main trigger section
                 
+                #ifdef USE_WATCHDOG
 #ifdef __AVR_XMEGA__
                 WDT_Reset();
 #else // __AVR_XMEGA__
                 wdt_reset();
 #endif // __AVR_XMEGA__
+                #endif // USE_WATCHDOG
                 
 #ifdef USE_ENTER_DELAY
         }
@@ -448,7 +450,11 @@ int main(void)
                 val = get_char();
                 
                 #ifdef USE_WATCHDOG
+#ifdef __AVR_XMEGA__
                 WDT_Reset();
+#else // __AVR_XMEGA__
+                wdt_reset();
+#endif // __AVR_XMEGA__
                 #endif // USE_WATCHDOG
                 
                 // Main bootloader parser
@@ -1100,7 +1106,15 @@ unsigned char __attribute__ ((noinline)) get_char(void)
 {
         unsigned char ret;
         
-        while (rx_char_cnt == 0) { };
+        while (rx_char_cnt == 0) {
+                #ifdef USE_WATCHDOG
+#ifdef __AVR_XMEGA__
+                WDT_Reset();
+#else // __AVR_XMEGA__
+                wdt_reset();
+#endif // __AVR_XMEGA__
+                #endif // USE_WATCHDOG
+        };
         
         cli();
         
@@ -1117,6 +1131,14 @@ void __attribute__ ((noinline)) send_char(unsigned char c)
 {
         while (1)
         {
+                #ifdef USE_WATCHDOG
+#ifdef __AVR_XMEGA__
+                WDT_Reset();
+#else // __AVR_XMEGA__
+                wdt_reset();
+#endif // __AVR_XMEGA__
+                #endif // USE_WATCHDOG
+
                 cli();
                 
                 if (tx_char_cnt == 0)
@@ -1158,6 +1180,14 @@ unsigned char __attribute__ ((noinline)) get_char(void)
         
         while (1)
         {
+                #ifdef USE_WATCHDOG
+#ifdef __AVR_XMEGA__
+                WDT_Reset();
+#else // __AVR_XMEGA__
+                wdt_reset();
+#endif // __AVR_XMEGA__
+                #endif // USE_WATCHDOG
+
                 #ifdef USE_UART
                 // Get next character
                 if (comm_mode == MODE_UNDEF || comm_mode == MODE_UART)
@@ -1282,6 +1312,14 @@ void __attribute__ ((noinline)) send_char(unsigned char c)
         {
                 while (1)
                 {
+                        #ifdef USE_WATCHDOG
+#ifdef __AVR_XMEGA__
+                        WDT_Reset();
+#else // __AVR_XMEGA__
+                        wdt_reset();
+#endif // __AVR_XMEGA__
+                        #endif // USE_WATCHDOG
+
 #ifdef __AVR_XMEGA__
                         if (i2c_address_match())
                         {
@@ -1360,7 +1398,11 @@ unsigned char BlockLoad(unsigned int size, unsigned char mem, ADDR_T *address)
         ADDR_T tempaddress;
         
         #ifdef USE_WATCHDOG
+#ifdef __AVR_XMEGA__
         WDT_Reset();
+#else // __AVR_XMEGA__
+        wdt_reset();
+#endif // __AVR_XMEGA__
         #endif // USE_WATCHDOG
         
         // fill up buffer


### PR DESCRIPTION
Added watchdog reset during blocking communication functions. Fixed some instances of WDT_Reset() being called instead of wdt_reset() on non-XMEGA builds, and watchdog reset being called on non-watchdog builds.